### PR TITLE
#4 게시글 댓글 기능 (작성/삭제) 구현

### DIFF
--- a/src/main/java/dev/devlink/article/comment/controller/closed/CommentController.java
+++ b/src/main/java/dev/devlink/article/comment/controller/closed/CommentController.java
@@ -1,0 +1,39 @@
+package dev.devlink.article.comment.controller.closed;
+
+import dev.devlink.article.comment.controller.request.CommentCreateRequest;
+import dev.devlink.article.comment.service.CommentService;
+import dev.devlink.common.dto.ApiResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/articles/{articleId}/comments")
+public class CommentController {
+
+    private final CommentService commentService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<Void>> create(
+            @PathVariable Long articleId,
+            @Validated @RequestBody CommentCreateRequest request,
+            HttpServletRequest httpRequest
+    ) {
+        Long memberId = (Long) httpRequest.getAttribute("memberId");
+        commentService.save(memberId, articleId, request);
+        return ResponseEntity.ok(ApiResponse.successEmpty());
+    }
+
+    @DeleteMapping("/{commentId}")
+    public ResponseEntity<ApiResponse<Void>> delete(
+            @PathVariable Long commentId,
+            HttpServletRequest request
+    ) {
+        Long memberId = (Long) request.getAttribute("memberId");
+        commentService.delete(commentId, memberId);
+        return ResponseEntity.ok(ApiResponse.successEmpty());
+    }
+}

--- a/src/main/java/dev/devlink/article/comment/controller/open/CommentPublicController.java
+++ b/src/main/java/dev/devlink/article/comment/controller/open/CommentPublicController.java
@@ -1,0 +1,27 @@
+package dev.devlink.article.comment.controller.open;
+
+import dev.devlink.article.comment.controller.response.CommentResponse;
+import dev.devlink.article.comment.service.CommentService;
+import dev.devlink.common.dto.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/public/articles/{articleId}/comments")
+public class CommentPublicController {
+
+    private final CommentService commentService;
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<CommentResponse>>> getComments(@PathVariable Long articleId) {
+        List<CommentResponse> responses = commentService.getCommentTreeByArticleId(articleId);
+        return ResponseEntity.ok(ApiResponse.success(responses));
+    }
+}

--- a/src/main/java/dev/devlink/article/comment/controller/request/CommentCreateRequest.java
+++ b/src/main/java/dev/devlink/article/comment/controller/request/CommentCreateRequest.java
@@ -1,0 +1,17 @@
+package dev.devlink.article.comment.controller.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CommentCreateRequest {
+
+    private Long parentId;
+
+    @NotBlank(message = "댓글 내용은 비어 있을 수 없습니다.")
+    @Size(min = 1, max = 10000, message = "댓글 내용은 1자 이상 10000자 이하이어야 합니다.")
+    private String content;
+}

--- a/src/main/java/dev/devlink/article/comment/controller/response/CommentResponse.java
+++ b/src/main/java/dev/devlink/article/comment/controller/response/CommentResponse.java
@@ -1,0 +1,33 @@
+package dev.devlink.article.comment.controller.response;
+
+import dev.devlink.article.comment.entity.Comment;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class CommentResponse {
+
+    private Long id;
+    private String content;
+    private String writer;
+    private List<CommentResponse> children = new ArrayList<>();
+    private LocalDateTime createdAt;
+
+    public static CommentResponse from(Comment comment) {
+        CommentResponse response = new CommentResponse();
+        response.id = comment.getId();
+        response.content = comment.getContent();
+        response.writer = comment.getMember().getNickname();
+        response.createdAt = comment.getCreatedAt();
+        return response;
+    }
+
+    public void addChild(CommentResponse child) {
+        this.children.add(child);
+    }
+}

--- a/src/main/java/dev/devlink/article/comment/entity/Comment.java
+++ b/src/main/java/dev/devlink/article/comment/entity/Comment.java
@@ -1,0 +1,59 @@
+package dev.devlink.article.comment.entity;
+
+import dev.devlink.article.entity.Article;
+import dev.devlink.common.BaseEntity;
+import dev.devlink.member.entity.Member;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Comment extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "article_id", nullable = false)
+    private Article article;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Column(nullable = false)
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_id")
+    private Comment parent;
+
+    public static Comment create(
+            Article article,
+            Member member,
+            String content,
+            Comment parent
+    ) {
+        Comment comment = new Comment();
+        comment.article = article;
+        comment.member = member;
+        comment.content = content;
+        comment.parent = parent;
+        return comment;
+    }
+
+    public Long getWriterId() {
+        return this.member.getId();
+    }
+
+    public Long getParentIdOrNull() {
+        if (parent != null) {
+            return parent.getId();
+        }
+        return null;
+    }
+}

--- a/src/main/java/dev/devlink/article/comment/exception/CommentError.java
+++ b/src/main/java/dev/devlink/article/comment/exception/CommentError.java
@@ -1,0 +1,20 @@
+package dev.devlink.article.comment.exception;
+
+import dev.devlink.common.exception.CommonError;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum CommentError implements CommonError {
+
+    NOT_FOUND(HttpStatus.NOT_FOUND, "40420", "존재하지 않는 댓글입니다."),
+    NO_PERMISSION(HttpStatus.FORBIDDEN, "40321", "댓글을 삭제할 권한이 없습니다."),
+    HAS_CHILD_COMMENTS(HttpStatus.BAD_REQUEST, "40022", "대댓글이 있어 삭제할 수 없습니다."),
+    PARENT_NOT_FOUND(HttpStatus.BAD_REQUEST, "40030", "부모 댓글이 존재하지 않습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/dev/devlink/article/comment/exception/CommentException.java
+++ b/src/main/java/dev/devlink/article/comment/exception/CommentException.java
@@ -1,0 +1,13 @@
+package dev.devlink.article.comment.exception;
+
+import dev.devlink.common.exception.CommonError;
+import dev.devlink.common.exception.ServiceException;
+import lombok.Getter;
+
+@Getter
+public class CommentException extends ServiceException {
+
+    public CommentException(CommonError commonError) {
+        super(commonError);
+    }
+}

--- a/src/main/java/dev/devlink/article/comment/repository/CommentRepository.java
+++ b/src/main/java/dev/devlink/article/comment/repository/CommentRepository.java
@@ -1,0 +1,13 @@
+package dev.devlink.article.comment.repository;
+
+import dev.devlink.article.comment.entity.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+    boolean existsByParentId(Long parentId);
+
+    List<Comment> findAllByArticleId(Long articleId);
+}

--- a/src/main/java/dev/devlink/article/comment/service/CommentService.java
+++ b/src/main/java/dev/devlink/article/comment/service/CommentService.java
@@ -1,0 +1,96 @@
+package dev.devlink.article.comment.service;
+
+import dev.devlink.article.comment.controller.request.CommentCreateRequest;
+import dev.devlink.article.comment.controller.response.CommentResponse;
+import dev.devlink.article.comment.entity.Comment;
+import dev.devlink.article.comment.exception.CommentError;
+import dev.devlink.article.comment.exception.CommentException;
+import dev.devlink.article.comment.repository.CommentRepository;
+import dev.devlink.article.entity.Article;
+import dev.devlink.article.service.ArticleService;
+import dev.devlink.member.entity.Member;
+import dev.devlink.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class CommentService {
+
+    private final MemberService memberService;
+    private final ArticleService articleService;
+    private final CommentRepository commentRepository;
+
+    @Transactional
+    public void save(Long articleId, Long memberId, CommentCreateRequest request) {
+        Article article = articleService.findArticleById(articleId);
+        Member member = memberService.findMemberById(memberId);
+
+        Comment parent = findParentOrNull(request.getParentId());
+
+        Comment comment = Comment.create(article, member, request.getContent(), parent);
+        commentRepository.save(comment);
+    }
+
+    private Comment findParentOrNull(Long parentId) {
+        if (parentId == null) {
+            return null; // 최상위 댓글
+        }
+        return commentRepository.findById(parentId)
+                .orElseThrow(() -> new CommentException(CommentError.PARENT_NOT_FOUND));
+    }
+
+    @Transactional(readOnly = true)
+    public List<CommentResponse> getCommentTreeByArticleId(Long articleId) {
+        List<Comment> comments = commentRepository.findAllByArticleId(articleId);
+
+        Map<Long, CommentResponse> responseMap = new HashMap<>();
+        List<CommentResponse> rootComments = new ArrayList<>();
+
+        for (Comment comment : comments) {
+            CommentResponse response = CommentResponse.from(comment);
+            responseMap.put(comment.getId(), response);
+
+            Long parentId = comment.getParentIdOrNull();
+            if (parentId == null) {
+                rootComments.add(response);
+                continue;
+            }
+
+            CommentResponse parent = responseMap.get(parentId);
+            if (parent != null) {
+                parent.addChild(response);
+            }
+        }
+        return rootComments;
+    }
+
+    @Transactional
+    public void delete(Long commentId, Long currentMemberId) {
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new CommentException(CommentError.NOT_FOUND));
+
+        validateWriterId(comment, currentMemberId);
+        validateHasNoChildComments(commentId);
+
+        commentRepository.delete(comment);
+    }
+
+    private void validateWriterId(Comment comment, Long currentMemberId) {
+        if (!comment.getWriterId().equals(currentMemberId)) {
+            throw new CommentException(CommentError.NO_PERMISSION);
+        }
+    }
+
+    private void validateHasNoChildComments(Long commentId) {
+        if (commentRepository.existsByParentId(commentId)) {
+            throw new CommentException(CommentError.HAS_CHILD_COMMENTS);
+        }
+    }
+}

--- a/src/main/webapp/WEB-INF/views/articles/update.jsp
+++ b/src/main/webapp/WEB-INF/views/articles/update.jsp
@@ -40,7 +40,8 @@
         contentType: "application/json",
         success: function (response) {
           console.log("글이 업데이트되었습니다.");
-          window.location.href = `/api/v1/view/articles/paging?page=${page}`;
+          <%--window.location.href = `/api/v1/view/articles/paging?page=${page}`;--%>
+          window.location.href = `/api/v1/view/articles/${id}`;
         },
         error: function (error) {
           console.error("글 업데이트 중 오류가 발생했습니다.", error);


### PR DESCRIPTION
## 주요 변경 사항

- [X] 게시글 댓글 작성 기능 구현
- [X] 대댓글(계층형 구조) 조회 기능 구현
- [X] 댓글 삭제 기능 구현 (자식 댓글 존재 시 삭제 제한)
- [X] 댓글 작성/삭제 시 권한 검사 로직 추가

## 작업 상세

- CommentService에 계층형 트리 변환 로직 추가 (`getCommentTreeByArticleId`)
- 댓글 삭제 시 본인 작성 여부 및 자식 존재 여부 검증 로직 추가
- 클라이언트 단 댓글 삭제 요청 기능(jQuery + AJAX) 구현
- 관련 예외 클래스 및 오류 코드 (`CommentError`, `CommentException`) 정리

## 테스트

- JSP 기반 UI에서 댓글 작성/삭제 정상 작동 확인

   - 대댓글 작성 → 부모 댓글 삭제 → 예외 발생 확인