### PR TITLE
#6 JWT 기반 인증 처리용 @AuthMemberId 리졸버 구현

### DIFF
--- a/src/main/java/dev/devlink/article/comment/controller/closed/CommentController.java
+++ b/src/main/java/dev/devlink/article/comment/controller/closed/CommentController.java
@@ -3,7 +3,7 @@ package dev.devlink.article.comment.controller.closed;
 import dev.devlink.article.comment.controller.request.CommentCreateRequest;
 import dev.devlink.article.comment.service.CommentService;
 import dev.devlink.common.dto.ApiResponse;
-import jakarta.servlet.http.HttpServletRequest;
+import dev.devlink.common.identity.annotation.AuthMemberId;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -20,9 +20,8 @@ public class CommentController {
     public ResponseEntity<ApiResponse<Void>> create(
             @PathVariable Long articleId,
             @Validated @RequestBody CommentCreateRequest request,
-            HttpServletRequest httpRequest
+            @AuthMemberId Long memberId
     ) {
-        Long memberId = (Long) httpRequest.getAttribute("memberId");
         commentService.save(memberId, articleId, request);
         return ResponseEntity.ok(ApiResponse.successEmpty());
     }
@@ -30,9 +29,8 @@ public class CommentController {
     @DeleteMapping("/{commentId}")
     public ResponseEntity<ApiResponse<Void>> delete(
             @PathVariable Long commentId,
-            HttpServletRequest request
+            @AuthMemberId Long memberId
     ) {
-        Long memberId = (Long) request.getAttribute("memberId");
         commentService.delete(commentId, memberId);
         return ResponseEntity.ok(ApiResponse.successEmpty());
     }

--- a/src/main/java/dev/devlink/article/controller/closed/ArticleController.java
+++ b/src/main/java/dev/devlink/article/controller/closed/ArticleController.java
@@ -4,7 +4,7 @@ import dev.devlink.article.controller.request.ArticleCreateRequest;
 import dev.devlink.article.controller.request.ArticleUpdateRequest;
 import dev.devlink.article.service.ArticleService;
 import dev.devlink.common.dto.ApiResponse;
-import jakarta.servlet.http.HttpServletRequest;
+import dev.devlink.common.identity.annotation.AuthMemberId;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -21,9 +21,8 @@ public class ArticleController {
     @PostMapping
     public ResponseEntity<ApiResponse<Void>> create(
             @Validated @RequestBody ArticleCreateRequest request,
-            HttpServletRequest httpRequest
+            @AuthMemberId Long memberId
     ) {
-        Long memberId = (Long) httpRequest.getAttribute("memberId");
         articleService.save(request, memberId);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.successEmpty());
@@ -33,9 +32,8 @@ public class ArticleController {
     public ResponseEntity<ApiResponse<Void>> update(
             @PathVariable Long id,
             @Validated @RequestBody ArticleUpdateRequest request,
-            HttpServletRequest httpRequest
+            @AuthMemberId Long memberId
     ) {
-        Long memberId = (Long) httpRequest.getAttribute("memberId");
         articleService.update(id, request, memberId);
         return ResponseEntity.ok(ApiResponse.successEmpty());
     }
@@ -43,9 +41,8 @@ public class ArticleController {
     @DeleteMapping("/{id}")
     public ResponseEntity<ApiResponse<Void>> delete(
             @PathVariable Long id,
-            HttpServletRequest request
+            @AuthMemberId Long memberId
     ) {
-        Long memberId = (Long) request.getAttribute("memberId");
         articleService.delete(id, memberId);
         return ResponseEntity.ok(ApiResponse.successEmpty());
     }

--- a/src/main/java/dev/devlink/article/controller/view/ArticleViewController.java
+++ b/src/main/java/dev/devlink/article/controller/view/ArticleViewController.java
@@ -4,8 +4,8 @@ import dev.devlink.article.controller.response.ArticleDetailsResponse;
 import dev.devlink.article.controller.response.ArticleListResponse;
 import dev.devlink.article.controller.response.PageNavigationInfo;
 import dev.devlink.article.service.ArticleService;
+import dev.devlink.common.identity.annotation.AuthMemberId;
 import dev.devlink.member.service.MemberService;
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -27,8 +27,7 @@ public class ArticleViewController {
     private final ArticleService articleService;
 
     @GetMapping("/save")
-    public String showSaveForm(Model model, HttpServletRequest request) {
-        Long memberId = (Long) request.getAttribute("memberId");
+    public String showSaveForm(@AuthMemberId Long memberId, Model model) {
         String nickname = memberService.findNicknameById(memberId);
         model.addAttribute("nickname", nickname);
         return "articles/save";

--- a/src/main/java/dev/devlink/common/configuration/WebMvcConfiguration.java
+++ b/src/main/java/dev/devlink/common/configuration/WebMvcConfiguration.java
@@ -1,17 +1,27 @@
 package dev.devlink.common.configuration;
 
+import dev.devlink.common.identity.resolver.AuthMemberIdArgumentResolver;
 import dev.devlink.common.interceptor.JwtAuthInterceptor;
 import dev.devlink.common.jwt.TokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
 
 @Configuration
 @RequiredArgsConstructor
 public class WebMvcConfiguration implements WebMvcConfigurer {
 
     private final TokenProvider tokenProvider;
+    private final AuthMemberIdArgumentResolver authResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(authResolver);
+    }
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {

--- a/src/main/java/dev/devlink/common/exception/ErrorCode.java
+++ b/src/main/java/dev/devlink/common/exception/ErrorCode.java
@@ -11,7 +11,8 @@ public enum ErrorCode implements CommonError {
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "400", "잘못된 요청입니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "500", "내부 서버 오류가 발생했습니다. 관리자에게 문의해주세요."),
     METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "405", "지원하지 않는 Http Method 입니다."),
-    INVALID_PARAMETER_TYPE(HttpStatus.BAD_REQUEST, "400", "잘못된 파라미터 타입입니다.");
+    INVALID_PARAMETER_TYPE(HttpStatus.BAD_REQUEST, "400", "잘못된 파라미터 타입입니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "401", "인증이 필요합니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/dev/devlink/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/dev/devlink/common/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package dev.devlink.common.exception;
 
 import dev.devlink.common.dto.ApiResponse;
+import dev.devlink.common.identity.exception.UnauthorizedException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -22,6 +23,17 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(
                 ApiResponse.failure(commonError.getMessage()),
                 HttpStatus.BAD_REQUEST
+        );
+    }
+
+    // 인증 오류 예외 처리
+    @ExceptionHandler(UnauthorizedException.class)
+    public ResponseEntity<ApiResponse<Void>> handleUnauthorized(UnauthorizedException ex) {
+        CommonError error = ex.getCommonError();
+        log.warn("인증 오류 발생: {}", error.getMessage());
+        return new ResponseEntity<>(
+                ApiResponse.failure(error.getMessage()),
+                error.getHttpStatus()
         );
     }
 

--- a/src/main/java/dev/devlink/common/identity/annotation/AuthMemberId.java
+++ b/src/main/java/dev/devlink/common/identity/annotation/AuthMemberId.java
@@ -1,0 +1,11 @@
+package dev.devlink.common.identity.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AuthMemberId {
+}

--- a/src/main/java/dev/devlink/common/identity/exception/UnauthorizedException.java
+++ b/src/main/java/dev/devlink/common/identity/exception/UnauthorizedException.java
@@ -1,0 +1,11 @@
+package dev.devlink.common.identity.exception;
+
+import dev.devlink.common.exception.ErrorCode;
+import dev.devlink.common.exception.ServiceException;
+
+public class UnauthorizedException extends ServiceException {
+
+    public UnauthorizedException() {
+        super(ErrorCode.UNAUTHORIZED);
+    }
+}

--- a/src/main/java/dev/devlink/common/identity/resolver/AuthMemberIdArgumentResolver.java
+++ b/src/main/java/dev/devlink/common/identity/resolver/AuthMemberIdArgumentResolver.java
@@ -1,0 +1,38 @@
+package dev.devlink.common.identity.resolver;
+
+import dev.devlink.common.identity.annotation.AuthMemberId;
+import dev.devlink.common.identity.exception.UnauthorizedException;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+public class AuthMemberIdArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(AuthMemberId.class) &&
+                parameter.getParameterType().equals(Long.class);
+    }
+
+    @Override
+    public Object resolveArgument(
+            MethodParameter parameter,
+            ModelAndViewContainer mavContainer,
+            NativeWebRequest webRequest,
+            WebDataBinderFactory binderFactory
+    ) {
+        HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+        Object memberIdAttr = request.getAttribute("memberId");
+
+        if (!(memberIdAttr instanceof Long)) {
+            throw new UnauthorizedException();
+        }
+
+        return memberIdAttr;
+    }
+}

--- a/src/main/java/dev/devlink/member/controller/closed/MemberController.java
+++ b/src/main/java/dev/devlink/member/controller/closed/MemberController.java
@@ -1,9 +1,9 @@
 package dev.devlink.member.controller.closed;
 
 import dev.devlink.common.dto.ApiResponse;
+import dev.devlink.common.identity.annotation.AuthMemberId;
 import dev.devlink.member.controller.response.AuthenticatedMemberResponse;
 import dev.devlink.member.service.MemberService;
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -19,10 +19,8 @@ public class MemberController {
 
     @GetMapping("/me")
     public ResponseEntity<ApiResponse<AuthenticatedMemberResponse>> getAuthenticatedMember(
-            HttpServletRequest request
+            @AuthMemberId Long memberId
     ) {
-        // TODO: 반복, 하드코딩 개선
-        Long memberId = (Long) request.getAttribute("memberId");
         AuthenticatedMemberResponse response = memberService.getAuthenticatedMember(memberId);
         return ResponseEntity.ok(ApiResponse.success(response));
     }


### PR DESCRIPTION
- [X] @AuthMemberId 어노테이션 추가: 컨트롤러 메서드에서 인증된 사용자 ID를 주입받기 위해 사용
- [X] AuthMemberIdArgumentResolver 구현:
    - [X] HttpServletRequest에서 JWT 인증 후 저장된 memberId를 추출하여 주입
    - [X] 인증 정보가 없거나 잘못된 경우 UnauthorizedException 예외 처리