### PR TITLE
#9 게시글 좋아요 기능 구현

### DIFF
--- a/src/main/java/dev/devlink/article/controller/closed/ArticleController.java
+++ b/src/main/java/dev/devlink/article/controller/closed/ArticleController.java
@@ -2,6 +2,7 @@ package dev.devlink.article.controller.closed;
 
 import dev.devlink.article.controller.request.ArticleCreateRequest;
 import dev.devlink.article.controller.request.ArticleUpdateRequest;
+import dev.devlink.article.service.ArticleLikeService;
 import dev.devlink.article.service.ArticleService;
 import dev.devlink.article.service.dto.response.ArticleDetailResponse;
 import dev.devlink.common.dto.ApiResponse;
@@ -18,6 +19,7 @@ import org.springframework.web.bind.annotation.*;
 public class ArticleController {
 
     private final ArticleService articleService;
+    private final ArticleLikeService articleLikeService;
 
     @PostMapping
     public ResponseEntity<ApiResponse<Void>> create(
@@ -55,5 +57,14 @@ public class ArticleController {
     ) {
         ArticleDetailResponse response = articleService.findDetail(id, memberId);
         return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @PostMapping("/{id}/likes")
+    public ResponseEntity<ApiResponse<Boolean>> toggleLike(
+            @PathVariable Long id,
+            @AuthMemberId Long memberId
+    ) {
+        boolean isLiked = articleLikeService.toggleLike(id, memberId);
+        return ResponseEntity.ok(ApiResponse.success(isLiked));
     }
 }

--- a/src/main/java/dev/devlink/article/controller/open/ArticlePublicController.java
+++ b/src/main/java/dev/devlink/article/controller/open/ArticlePublicController.java
@@ -1,5 +1,6 @@
 package dev.devlink.article.controller.open;
 
+import dev.devlink.article.service.ArticleLikeService;
 import dev.devlink.article.service.ArticleService;
 import dev.devlink.article.service.dto.response.ArticleListResponse;
 import dev.devlink.common.dto.ApiResponse;
@@ -10,6 +11,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -19,6 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class ArticlePublicController {
 
     private final ArticleService articleService;
+    private final ArticleLikeService articleLikeService;
 
     @GetMapping
     public ResponseEntity<ApiResponse<Page<ArticleListResponse>>> getPagedArticles(
@@ -26,5 +29,13 @@ public class ArticlePublicController {
     ) {
         Page<ArticleListResponse> articlePage = articleService.findArticlesByPage(pageable);
         return ResponseEntity.ok(ApiResponse.success(articlePage));
+    }
+
+    @GetMapping("/{id}/likes")
+    public ResponseEntity<ApiResponse<Long>> countLikes(
+            @PathVariable Long id
+    ) {
+        long count = articleLikeService.countLikes(id);
+        return ResponseEntity.ok(ApiResponse.success(count));
     }
 }

--- a/src/main/java/dev/devlink/article/entity/ArticleLike.java
+++ b/src/main/java/dev/devlink/article/entity/ArticleLike.java
@@ -1,0 +1,39 @@
+package dev.devlink.article.entity;
+
+import dev.devlink.common.BaseEntity;
+import dev.devlink.member.entity.Member;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"article_id", "member_id"})
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ArticleLike extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "article_id", nullable = false)
+    private Article article;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Builder
+    public ArticleLike(Article article, Member member) {
+        this.article = article;
+        this.member = member;
+    }
+
+    public static ArticleLike create(Article article, Member member) {
+        return ArticleLike.builder()
+                .article(article)
+                .member(member)
+                .build();
+    }
+}

--- a/src/main/java/dev/devlink/article/repository/ArticleLikeRepository.java
+++ b/src/main/java/dev/devlink/article/repository/ArticleLikeRepository.java
@@ -1,0 +1,15 @@
+package dev.devlink.article.repository;
+
+import dev.devlink.article.entity.Article;
+import dev.devlink.article.entity.ArticleLike;
+import dev.devlink.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ArticleLikeRepository extends JpaRepository<ArticleLike, Long> {
+
+    long countByArticle(Article article);
+
+    Optional<ArticleLike> findByArticleAndMember(Article article, Member member);
+}

--- a/src/main/java/dev/devlink/article/service/ArticleLikeService.java
+++ b/src/main/java/dev/devlink/article/service/ArticleLikeService.java
@@ -1,0 +1,54 @@
+package dev.devlink.article.service;
+
+import dev.devlink.article.entity.Article;
+import dev.devlink.article.entity.ArticleLike;
+import dev.devlink.article.exception.ArticleError;
+import dev.devlink.article.exception.ArticleException;
+import dev.devlink.article.repository.ArticleLikeRepository;
+import dev.devlink.article.repository.ArticleRepository;
+import dev.devlink.member.entity.Member;
+import dev.devlink.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class ArticleLikeService {
+
+    private final ArticleLikeRepository articleLikeRepository;
+    private final ArticleRepository articleRepository;
+    private final MemberService memberService;
+
+    @Transactional
+    public boolean toggleLike(Long articleId, Long memberId) {
+        Member member = memberService.findMemberById(memberId);
+        Article article = articleRepository.findById(articleId)
+                .orElseThrow(() -> new ArticleException(ArticleError.ARTICLE_NOT_FOUND));
+
+        Optional<ArticleLike> existingLike = articleLikeRepository
+                .findByArticleAndMember(article, member);
+
+        if (existingLike.isPresent()) {
+            articleLikeRepository.delete(existingLike.get());
+            return false;
+        }
+
+        addLike(article, member);
+        return true;
+    }
+
+    private void addLike(Article article, Member member) {
+        ArticleLike newLike = ArticleLike.create(article, member);
+        articleLikeRepository.save(newLike);
+    }
+
+    @Transactional(readOnly = true)
+    public long countLikes(Long articleId) {
+        Article article = articleRepository.findById(articleId)
+                .orElseThrow(() -> new ArticleException(ArticleError.ARTICLE_NOT_FOUND));
+        return articleLikeRepository.countByArticle(article);
+    }
+}

--- a/src/main/webapp/WEB-INF/views/articles/detail.jsp
+++ b/src/main/webapp/WEB-INF/views/articles/detail.jsp
@@ -101,6 +101,7 @@
           console.error("게시글 정보를 불러오는데 실패했습니다.");
         }
       });
+      loadLikeCount();
       loadComments();
     });
 
@@ -296,6 +297,38 @@
       return date.toLocaleString("ko-KR", {
         year: 'numeric', month: '2-digit', day: '2-digit',
         hour: '2-digit', minute: '2-digit'
+      });
+    }
+
+
+
+    function toggleLike() {
+      $.ajax({
+        url: "/api/v1/articles/" + articleId + "/likes",
+        type: "POST",
+        headers: {
+          'Authorization': 'Bearer ' + localStorage.getItem("jwt")
+        },
+        success: function(response) {
+          const liked = response.data;
+          loadLikeCount(); // 최신 좋아요 수 다시 로딩
+        },
+        error: function(xhr) {
+          Swal.fire("오류", "좋아요 요청 실패: " + (xhr.responseJSON?.message || xhr.responseText), "error");
+        }
+      });
+    }
+
+    function loadLikeCount() {
+      $.ajax({
+        url: "/api/public/articles/" + articleId + "/likes",
+        type: "GET",
+        success: function(response) {
+          $("#likesCount").text(response.data);
+        },
+        error: function(xhr) {
+          console.error("좋아요 수 조회 실패:", xhr.responseText);
+        }
       });
     }
   </script>


### PR DESCRIPTION
## 작업 내용
- [x] 게시글 좋아요 기능 전체 구현
- [x] ArticleLike 엔티티 생성 및 @UniqueConstraint(article_id, member_id) 적용
- [x] ArticleController에 API 추가
  - [x] 좋아요 토글 기능 (`POST /api/v1/articles/{id}/likes`)
  - [x] 좋아요 개수 조회 기능 (`GET /api/v1/articles/{id}/likes`)
- [x] 게시글 상세 뷰에 좋아요 버튼 연동 및 동작 구현

## 테스트
- [x] 게시글 상세 페이지에서 좋아요 버튼 클릭 시 상태 토글 확인
- [x] 동일 유저가 두 번 클릭하면 좋아요 취소
- [x] 좋아요 수가 즉시 반영됨