### PR TITLE
#10 인기글 Top 5 기능 구현

### DIFF
--- a/src/main/java/dev/devlink/article/controller/open/ArticlePublicController.java
+++ b/src/main/java/dev/devlink/article/controller/open/ArticlePublicController.java
@@ -1,6 +1,7 @@
 package dev.devlink.article.controller.open;
 
 import dev.devlink.article.service.ArticleLikeService;
+import dev.devlink.article.service.ArticleRankingService;
 import dev.devlink.article.service.ArticleService;
 import dev.devlink.article.service.dto.response.ArticleListResponse;
 import dev.devlink.common.dto.ApiResponse;
@@ -15,6 +16,8 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/public/articles")
@@ -22,6 +25,7 @@ public class ArticlePublicController {
 
     private final ArticleService articleService;
     private final ArticleLikeService articleLikeService;
+    private final ArticleRankingService articleRankingService;
 
     @GetMapping
     public ResponseEntity<ApiResponse<Page<ArticleListResponse>>> getPagedArticles(
@@ -37,5 +41,11 @@ public class ArticlePublicController {
     ) {
         long count = articleLikeService.countLikes(id);
         return ResponseEntity.ok(ApiResponse.success(count));
+    }
+
+    @GetMapping("/best")
+    public ResponseEntity<ApiResponse<List<ArticleListResponse>>> getTopFiveArticles() {
+        List<ArticleListResponse> response = articleRankingService.findTopRankedArticles();
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 }

--- a/src/main/java/dev/devlink/article/service/ArticleRankingService.java
+++ b/src/main/java/dev/devlink/article/service/ArticleRankingService.java
@@ -1,0 +1,66 @@
+package dev.devlink.article.service;
+
+import dev.devlink.article.entity.Article;
+import dev.devlink.article.repository.ArticleRepository;
+import dev.devlink.article.service.dto.response.ArticleListResponse;
+import dev.devlink.common.redis.RedisConstants;
+import dev.devlink.common.redis.RedisKey;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ArticleRankingService {
+
+    private final StringRedisTemplate redisTemplate;
+    private final ArticleRepository articleRepository;
+    private final ArticleViewService articleViewService;
+
+    public void addViewAndRank(Long articleId, Long memberId) {
+        boolean isFirstVisit = articleViewService.addView(articleId, memberId);
+        if (isFirstVisit) {
+            redisTemplate.opsForZSet().incrementScore(
+                    RedisKey.articleRanking(),
+                    articleId.toString(),
+                    RedisConstants.SCORE
+            );
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public List<ArticleListResponse> findTopRankedArticles() {
+        List<Long> topArticleIds = getTopFiveArticleIds();
+        Map<Long, Article> articleMap = articleRepository.findAllById(topArticleIds)
+                .stream()
+                .collect(Collectors.toMap(Article::getId, Function.identity()));
+
+        return topArticleIds.stream()
+                .map(id -> createResponse(id, articleMap.get(id)))
+                .filter(Objects::nonNull)
+                .toList();
+    }
+
+    private ArticleListResponse createResponse(Long id, Article article) {
+        if (article == null) return null;
+
+        Long dbViewCount = article.getViewCount();
+        Long totalViewCount = articleViewService.getTotalViewCount(id, dbViewCount);
+        return ArticleListResponse.from(article, totalViewCount);
+    }
+
+    public List<Long> getTopFiveArticleIds() {
+        return redisTemplate.opsForZSet()
+                .reverseRange(RedisKey.articleRanking(), 0, RedisConstants.TOP_LIMIT - 1)
+                .stream()
+                .map(Long::parseLong)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/dev/devlink/article/service/ArticleService.java
+++ b/src/main/java/dev/devlink/article/service/ArticleService.java
@@ -23,8 +23,9 @@ import org.springframework.transaction.annotation.Transactional;
 public class ArticleService {
 
     private final MemberService memberService;
-    private final ArticleViewService articleViewService;
     private final ArticleRepository articleRepository;
+    private final ArticleViewService articleViewService;
+    private final ArticleRankingService articleRankingService;
 
     @Transactional
     public void save(ArticleCreateServiceDto command) {
@@ -38,7 +39,7 @@ public class ArticleService {
         Article article = articleRepository.findDetailById(articleId)
                 .orElseThrow(() -> new ArticleException(ArticleError.ARTICLE_NOT_FOUND));
 
-        articleViewService.addUniqueView(articleId, memberId);
+        articleRankingService.addViewAndRank(articleId, memberId);
         Long dbViewCount = article.getViewCount();
         Long totalViewCount = articleViewService.getTotalViewCount(articleId, dbViewCount);
 

--- a/src/main/java/dev/devlink/article/service/dto/response/ArticleListResponse.java
+++ b/src/main/java/dev/devlink/article/service/dto/response/ArticleListResponse.java
@@ -13,6 +13,7 @@ public class ArticleListResponse {
     private String writer;
     private Long writerId;
     private String formattedCreatedAt;
+    private Long viewCount;
 
     public static ArticleListResponse from(Article article) {
         return new ArticleListResponse(
@@ -20,7 +21,19 @@ public class ArticleListResponse {
                 article.getTitle(),
                 article.getWriterNickname(),
                 article.getWriterId(),
-                DateUtils.formatLocalDateTime(article.getCreatedAt())
+                DateUtils.formatLocalDateTime(article.getCreatedAt()),
+                article.getViewCount()
+        );
+    }
+
+    public static ArticleListResponse from(Article article, Long totalViewCount) {
+        return new ArticleListResponse(
+                article.getId(),
+                article.getTitle(),
+                article.getWriterNickname(),
+                article.getWriterId(),
+                DateUtils.formatLocalDateTime(article.getCreatedAt()),
+                totalViewCount
         );
     }
 }

--- a/src/main/java/dev/devlink/common/redis/RedisConstants.java
+++ b/src/main/java/dev/devlink/common/redis/RedisConstants.java
@@ -6,7 +6,12 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class RedisConstants {
 
-    public static final long VIEW_SYNC_INTERVAL = 600_000L;
-    public static final long VIEW_DUPLICATE_PREVENTION_TTL = 3600L;
-    public static final String VIEW_TRACKING_MARKER = "VIEWED";
+    // 조회수 관련
+    public static final long SYNC_INTERVAL_MILLIS = 300_000L;
+    public static final long DUPLICATE_PREVENTION_TTL = 3600L;
+    public static final String TRACKING_MARKER = "VIEWED";
+
+    // 랭킹 관련
+    public static final int TOP_LIMIT = 5;
+    public static final double SCORE = 1.0;
 }

--- a/src/main/resources/static/css/articles/paging.css
+++ b/src/main/resources/static/css/articles/paging.css
@@ -103,3 +103,7 @@ button {
 button:hover {
     background-color: #357ABD;
 }
+
+.top-articles {
+    padding: 10px 0;
+}

--- a/src/main/webapp/WEB-INF/views/articles/paging.jsp
+++ b/src/main/webapp/WEB-INF/views/articles/paging.jsp
@@ -31,6 +31,14 @@
         </div>
     </div>
 
+    <!-- Top 5 인기글 영역: 여기 추가 -->
+    <div class="top-articles mb-4">
+        <h4 style="margin-bottom: 16px;">🔥인기 스터디 TOP 5</h4>
+        <ul id="topArticlesList" class="list-group">
+            <!-- JS에서 동적으로 인기글 삽입 -->
+        </ul>
+    </div>
+
     <table>
         <thead>
         <tr>
@@ -65,6 +73,7 @@
 
         const pageSize = 8;
         loadArticles(currentPage, pageSize);
+        loadTopArticles();
     });
 
     function loadArticles(page, size) {
@@ -112,6 +121,43 @@
                 '</tr>';
 
             tbody.append(row);
+        });
+    }
+
+    function loadTopArticles() {
+        $.ajax({
+            url: '/api/public/articles/best',
+            type: 'GET',
+            success: function (res) {
+                const topArticles = res.data;
+                renderTopArticles(topArticles);
+            },
+            error: function () {
+                console.error('인기 게시글을 불러오는 데 실패했습니다.');
+            }
+        });
+    }
+
+    function renderTopArticles(articles) {
+        const list = $('#topArticlesList');
+        list.empty();
+
+        if (!articles || articles.length === 0) {
+            list.append('<li class="list-group-item">인기 게시글이 없습니다.</li>');
+            return;
+        }
+
+        articles.forEach((article, index) => {
+            const rank = index + 1; // 1위부터 시작
+            const item =
+                '<li class="list-group-item d-flex justify-content-between align-items-center">' +
+                '<div>' +
+                '<strong>' + rank + '위. </strong>' +
+                '<a href="/view/articles/' + article.id + '">' + article.title + '</a>' +
+                '</div>' +
+                '<span class="badge badge-primary badge-pill">' + article.viewCount + ' 조회</span>' +
+                '</li>';
+            list.append(item);
         });
     }
 


### PR DESCRIPTION
## 작업 내용
- [X] Redis ZSet을 활용한 인기글 랭킹 기능 구현
- [X] ArticleRankingService 클래스 생성 (책임 분리)
- [X] 조회수 기반 반영, 랭킹 상위 5개 게시글 조회

## 설계 및 구조 고민
- [X] Redis ZSet 구조: `value = articleId`, `score = 조회수` 형식 저장
- [X] `findAllById(List<Long>)`는 정렬이 보장되지 않으므로 `Map<Long, Article>`로 매핑 후 Redis 기준 순서대로 응답 조립
- [X] Redis의 조회수와 DB 조회수를 합산하여 실제 viewCount를 계산

테스트
- [X] 게시글 상세 페이지 조회 시 Redis ZSet에 점수 반영되는지 확인
- [X] Redis에서 상위 5개 게시글이 조회수 높은 순으로 정렬되어 반환되는지 확인