### PR TITLE
#18 조회수 DB 반영에 JDBC 배치 적용

### DIFF
--- a/src/main/java/dev/devlink/article/repository/ArticleRepository.java
+++ b/src/main/java/dev/devlink/article/repository/ArticleRepository.java
@@ -4,7 +4,6 @@ import dev.devlink.article.entity.Article;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -18,10 +17,6 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
 
     @Query("SELECT a FROM Article a JOIN FETCH a.member WHERE a.id = :id")
     Optional<Article> findDetailById(@Param("id") Long id);
-
-    @Modifying
-    @Query("UPDATE Article a SET a.viewCount = a.viewCount + :increment WHERE a.id = :articleId")
-    void bulkAddViewCount(@Param("articleId") Long articleId, @Param("increment") Long increment);
 
     @Query("SELECT a FROM Article a ORDER BY a.viewCount DESC")
     List<Article> findTopByViews(Pageable pageable);

--- a/src/main/java/dev/devlink/article/service/ArticleViewBatchUpdater.java
+++ b/src/main/java/dev/devlink/article/service/ArticleViewBatchUpdater.java
@@ -1,0 +1,28 @@
+package dev.devlink.article.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class ArticleViewBatchUpdater {
+
+    private static final int BATCH_SIZE = 500;
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public void batchUpdate(List<Object[]> batchArgs) {
+        if (batchArgs.isEmpty()) return;
+
+        String sql = "UPDATE article SET view_count = view_count + ? WHERE id = ?";
+        
+        for (int startIndex = 0; startIndex < batchArgs.size(); startIndex += BATCH_SIZE) {
+            int endIndex = Math.min(startIndex + BATCH_SIZE, batchArgs.size());
+            List<Object[]> batch = batchArgs.subList(startIndex, endIndex);
+            jdbcTemplate.batchUpdate(sql, batch);
+        }
+    }
+}


### PR DESCRIPTION
## 작업 내용
- [X] JPA 반복 업데이트 제거 → JdbcTemplate.batchUpdate로 일괄 반영
- [X] 500건 단위 슬라이싱 처리로 메모리 절감
- [X] 동기화 대상(Set: articlesSaveDbKey) 기반으로만 Redis → DB 반영
- [X] DB 반영 성공 시 조회수 키와 대상 Set 항목 삭제