### PR TITLE
#19 Redis 조회수 데이터 MySQL 배치 업데이트

### DIFF
--- a/src/main/java/dev/devlink/article/service/ArticleRankingService.java
+++ b/src/main/java/dev/devlink/article/service/ArticleRankingService.java
@@ -56,7 +56,9 @@ public class ArticleRankingService {
         List<String> topArticleIds = redisTemplate.opsForList()
                 .range(key, RedisConstants.START_INDEX, RedisConstants.TOP_LIMIT - 1);
 
-        if (topArticleIds == null) return List.of();
+        if (topArticleIds == null) {
+            return List.of();
+        }
 
         return topArticleIds.stream()
                 .map(Long::parseLong)

--- a/src/main/java/dev/devlink/article/service/ArticleViewBatchUpdater.java
+++ b/src/main/java/dev/devlink/article/service/ArticleViewBatchUpdater.java
@@ -36,9 +36,9 @@ public class ArticleViewBatchUpdater {
             parameterSources.add(source);
         }
         
-        for (int i = 0; i < parameterSources.size(); i += BATCH_SIZE) {
-            int endIndex = Math.min(i + BATCH_SIZE, parameterSources.size());
-            List<MapSqlParameterSource> batch = parameterSources.subList(i, endIndex);
+        for (int startIndex = 0; startIndex < parameterSources.size(); startIndex += BATCH_SIZE) {
+            int endIndex = Math.min(startIndex + BATCH_SIZE, parameterSources.size());
+            List<MapSqlParameterSource> batch = parameterSources.subList(startIndex, endIndex);
             namedJdbcTemplate.batchUpdate(sql, batch.toArray(new MapSqlParameterSource[0]));
         }
     }

--- a/src/main/java/dev/devlink/article/service/ArticleViewBatchUpdater.java
+++ b/src/main/java/dev/devlink/article/service/ArticleViewBatchUpdater.java
@@ -1,5 +1,6 @@
 package dev.devlink.article.service;
 
+import dev.devlink.article.service.dto.ViewCountUpdateDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
@@ -7,18 +8,19 @@ import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 @Component
 @RequiredArgsConstructor
 public class ArticleViewBatchUpdater {
 
     private static final int BATCH_SIZE = 500;
+    private static final String PARAM_VIEW_COUNT = "viewCount";
+    private static final String PARAM_ARTICLE_ID = "articleId";
 
     private final NamedParameterJdbcTemplate namedJdbcTemplate;
 
-    public void batchUpdate(Map<Long, Long> viewCounts) {
-        if (viewCounts.isEmpty()) return;
+    public void batchUpdate(List<ViewCountUpdateDto> updateList) {
+        if (updateList.isEmpty()) return;
 
         String sql = """
             UPDATE article 
@@ -27,13 +29,13 @@ public class ArticleViewBatchUpdater {
             """;
 
         List<MapSqlParameterSource> parameterSources = new ArrayList<>();
-        for (Map.Entry<Long, Long> entry : viewCounts.entrySet()) {
+        for (ViewCountUpdateDto dto : updateList) {
             MapSqlParameterSource source = new MapSqlParameterSource()
-                    .addValue("viewCount", entry.getValue())
-                    .addValue("articleId", entry.getKey());
+                    .addValue(PARAM_VIEW_COUNT, dto.getViewCount())
+                    .addValue(PARAM_ARTICLE_ID, dto.getArticleId());
             parameterSources.add(source);
         }
-
+        
         for (int i = 0; i < parameterSources.size(); i += BATCH_SIZE) {
             int endIndex = Math.min(i + BATCH_SIZE, parameterSources.size());
             List<MapSqlParameterSource> batch = parameterSources.subList(i, endIndex);

--- a/src/main/java/dev/devlink/article/service/ArticleViewBatchUpdater.java
+++ b/src/main/java/dev/devlink/article/service/ArticleViewBatchUpdater.java
@@ -1,10 +1,13 @@
 package dev.devlink.article.service;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Component;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 @Component
 @RequiredArgsConstructor
@@ -12,17 +15,29 @@ public class ArticleViewBatchUpdater {
 
     private static final int BATCH_SIZE = 500;
 
-    private final JdbcTemplate jdbcTemplate;
+    private final NamedParameterJdbcTemplate namedJdbcTemplate;
 
-    public void batchUpdate(List<Object[]> batchArgs) {
-        if (batchArgs.isEmpty()) return;
+    public void batchUpdate(Map<Long, Long> viewCounts) {
+        if (viewCounts.isEmpty()) return;
 
-        String sql = "UPDATE article SET view_count = view_count + ? WHERE id = ?";
-        
-        for (int startIndex = 0; startIndex < batchArgs.size(); startIndex += BATCH_SIZE) {
-            int endIndex = Math.min(startIndex + BATCH_SIZE, batchArgs.size());
-            List<Object[]> batch = batchArgs.subList(startIndex, endIndex);
-            jdbcTemplate.batchUpdate(sql, batch);
+        String sql = """
+            UPDATE article 
+            SET view_count = view_count + :viewCount 
+            WHERE id = :articleId
+            """;
+
+        List<MapSqlParameterSource> parameterSources = new ArrayList<>();
+        for (Map.Entry<Long, Long> entry : viewCounts.entrySet()) {
+            MapSqlParameterSource source = new MapSqlParameterSource()
+                    .addValue("viewCount", entry.getValue())
+                    .addValue("articleId", entry.getKey());
+            parameterSources.add(source);
+        }
+
+        for (int i = 0; i < parameterSources.size(); i += BATCH_SIZE) {
+            int endIndex = Math.min(i + BATCH_SIZE, parameterSources.size());
+            List<MapSqlParameterSource> batch = parameterSources.subList(i, endIndex);
+            namedJdbcTemplate.batchUpdate(sql, batch.toArray(new MapSqlParameterSource[0]));
         }
     }
 }

--- a/src/main/java/dev/devlink/article/service/ArticleViewService.java
+++ b/src/main/java/dev/devlink/article/service/ArticleViewService.java
@@ -47,16 +47,18 @@ public class ArticleViewService {
     @Transactional
     public void bulkUpdateViewCounts() {
         Set<String> articleIds = redisTemplate.opsForSet().members(RedisKey.articlesSaveDbKey());
-        if (articleIds == null) return;
+        if (articleIds == null) {
+            return;
+        }
 
         List<ViewCountUpdateDto> updateList = new ArrayList<>();
         List<Long> cacheRemoveIds = new ArrayList<>();
-        
+
         for (String articleIdStr : articleIds) {
             Long articleId = Long.parseLong(articleIdStr);
             String viewCountValue = redisTemplate.opsForValue()
                     .get(RedisKey.getArticleViewKey(articleId));
-            
+
             if (viewCountValue != null) {
                 Long viewCount = Long.parseLong(viewCountValue);
                 updateList.add(new ViewCountUpdateDto(articleId, viewCount));

--- a/src/main/java/dev/devlink/article/service/dto/ViewCountUpdateDto.java
+++ b/src/main/java/dev/devlink/article/service/dto/ViewCountUpdateDto.java
@@ -1,0 +1,12 @@
+package dev.devlink.article.service.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ViewCountUpdateDto {
+
+    private final Long articleId;
+    private final Long viewCount;
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,7 +9,7 @@ spring:
     filter:
       enabled: true
   datasource:
-    url: jdbc:mysql://localhost:3306/logbook?useUnicode=true&serverTimezone=Asia/Seoul&autoReconnect=true&rewriteBatchedStatements=true
+    url: jdbc:mysql://localhost:3306/logbook?useUnicode=true&serverTimezone=Asia/Seoul&autoReconnect=true&allowMultiQueries=true
     username: seok
     password: 1234
   jpa:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,7 +9,7 @@ spring:
     filter:
       enabled: true
   datasource:
-    url: jdbc:mysql://localhost:3306/logbook?useUnicode=true&serverTimezone=Asia/Seoul&autoReconnect=true
+    url: jdbc:mysql://localhost:3306/logbook?useUnicode=true&serverTimezone=Asia/Seoul&autoReconnect=true&rewriteBatchedStatements=true
     username: seok
     password: 1234
   jpa:


### PR DESCRIPTION
## 작업 내용

- [X] Redis 조회수 데이터를 MySQL에 배치 업데이트
     - [X] allowMultiQueries=true 옵션 설정으로 성능 개선
- [X] NamedParameterJdbcTemplate으로 타입으로 변경
     - [X]  Object[] 제거 -> Dto 생성
- [X] 500개 청크 단위로 DB 부하 방지